### PR TITLE
Add Admin Dashboard and namespacing with Admin authorization

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < ApplicationController
+  before_action :require_admin
+
+  def require_admin
+    render file: "/public/404" unless current_admin?
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,4 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,5 +15,10 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
+  def current_admin?
+    current_user && current_user.admin?
+  end
+
   helper_method :current_user
+  helper_method :current_admin?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ActiveRecord::Base
     format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i }
   validates :password, length: { minimum: 8 }
 
+  enum role: %w(default admin)
+
   private
 
   def strip_whitespace

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,3 @@
+<div class="container">
+  <h3 class="text-center">Admin Dashboard</h3>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,8 @@ Rails.application.routes.draw do
   get "/login",  to: "sessions#new"
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
+
+  namespace :admin do
+    get "/dashboard", to: "users#index"
+  end
 end

--- a/spec/features/admin_can_view_admin_dashboard_spec.rb
+++ b/spec/features/admin_can_view_admin_dashboard_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 feature "Admin can view Admin Dashboard" do
   scenario "Admin logs in and sees Admin Dashboard for /admin/dashboard" do
     User.create(first_name: "Admin",
-                        last_name: "Admin",
-                        email: "admin@admin.com",
-                        password: "password",
-                        role: 1)
+                last_name: "Admin",
+                email: "admin@admin.com",
+                password: "password",
+                role: 1)
 
     visit "/login"
 
@@ -22,10 +22,10 @@ feature "Admin can view Admin Dashboard" do
 
   scenario "Non-admin logs in and sees 404 page for /admin/dashboard" do
     User.create(first_name: "Jane",
-                        last_name: "Doe",
-                        email: "jane@doe.com",
-                        password: "password",
-                        role: 0)
+                last_name: "Doe",
+                email: "jane@doe.com",
+                password: "password",
+                role: 0)
 
     visit "/login"
 

--- a/spec/features/admin_can_view_admin_dashboard_spec.rb
+++ b/spec/features/admin_can_view_admin_dashboard_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+feature "Admin can view Admin Dashboard" do
+  scenario "Admin logs in and sees Admin Dashboard for /admin/dashboard" do
+    User.create(first_name: "Admin",
+                        last_name: "Admin",
+                        email: "admin@admin.com",
+                        password: "password",
+                        role: 1)
+
+    visit "/login"
+
+    fill_in "Email", with: "admin@admin.com"
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboard"
+
+    expect(current_path).to eq("/admin/dashboard")
+    expect(page).to have_content("Admin Dashboard")
+  end
+
+  scenario "Non-admin logs in and sees 404 page for /admin/dashboard" do
+    User.create(first_name: "Jane",
+                        last_name: "Doe",
+                        email: "jane@doe.com",
+                        password: "password",
+                        role: 0)
+
+    visit "/login"
+
+    fill_in "Email", with: "jane@doe.com"
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboard"
+
+    expect(page).to have_content("The page you were looking for doesn't exist.")
+  end
+
+  scenario "Non-user sees 404 page for /admin/dashboard" do
+    visit "/admin/dashboard"
+
+    expect(page).to have_content("The page you were looking for doesn't exist.")
+  end
+end


### PR DESCRIPTION
The Admin Dashboard currently points to the Admin's User Index page, but displays only a header until further direction is received for this page. The admin must manually go to '/admin/dashboard' after logging in with role set to 1 (admin) (per user story).