### PR TITLE
17 delete items from cart

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -160,6 +160,13 @@ h6 {
   background: #428bca;
 }
 
+// flash messages
+.flash {
+  a {
+    color: #ffffff;
+    text-decoration: underline;    
+  }
+}
 
 // 404 Page Styles
 

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,29 +1,34 @@
 class CartItemsController < ApplicationController
+  before_action :set_product, only: [:create, :update, :destroy]
+
   def index
     @cart_items = cart.cart_items
   end
 
   def create
-    product = Product.find(params[:product_id])
-    flash[:success] = "#{product.name} added to cart"
-    cart.add_item(product)
+    flash[:success] = "#{@product.name} added to cart"
+    cart.add_item(@product)
     session[:cart] = cart.data
-    redirect_to product_path(product)
+    redirect_to product_path(@product)
   end
 
   def update
-    product_id = params[:id]
-    cart.data[product_id] = params[:product][:quantity].to_i
+    cart.update_item_quantity(@product, params[:product][:quantity].to_i)
     session[:cart] = cart.data
     redirect_to cart_path
   end
 
   def destroy
-    product = Product.find(params[:id])
     flash[:success] = "Successfully removed " \
-                      "<a href=\"#{product_path(product)}\">" \
-                      "#{product.name}</a> from your cart."
-    cart.delete_item(product)
+                      "<a href=\"#{product_path(@product)}\">" \
+                      "#{@product.name}</a> from your cart."
+    cart.delete_item(@product)
     redirect_to cart_path
+  end
+
+  private
+
+  def set_product
+    @product = Product.find(params[:id] || params[:product_id])
   end
 end

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -20,6 +20,9 @@ class CartItemsController < ApplicationController
 
   def destroy
     product = Product.find(params[:id])
+    flash[:success] = "Successfully removed " \
+                      "<a href=\"#{product_path(product)}\">" \
+                      "#{product.name}</a> from your cart."
     cart.delete_item(product)
     redirect_to cart_path
   end

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -23,6 +23,7 @@ class CartItemsController < ApplicationController
                       "<a href=\"#{product_path(@product)}\">" \
                       "#{@product.name}</a> from your cart."
     cart.delete_item(@product)
+    session[:cart] = cart.data
     redirect_to cart_path
   end
 

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -17,4 +17,10 @@ class CartItemsController < ApplicationController
     session[:cart] = cart.data
     redirect_to cart_path
   end
+
+  def destroy
+    product = Product.find(params[:id])
+    cart.delete_item(product)
+    redirect_to cart_path
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -23,6 +23,10 @@ class Cart
     data[product.id.to_s] +=  1
   end
 
+  def delete_item(product)
+    data.delete(product.id.to_s)
+  end
+
   def total_price
     cart_items.reduce(0) do |total, cart_item|
       total + cart_item.item_total

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -23,6 +23,10 @@ class Cart
     data[product.id.to_s] +=  1
   end
 
+  def update_item_quantity(product, quantity)
+    data[product.id.to_s] = quantity
+  end
+
   def delete_item(product)
     data.delete(product.id.to_s)
   end

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -4,29 +4,31 @@
   <div class="table-responsive">
     <div class="table table-hover">
       <div class="row">
-        <div class="col-sm-3 col-md-3">&nbsp;</div>
+        <div class="col-sm-3 col-md-2">&nbsp;</div>
         <div class="col-sm-5 col-md-5">Product</div>
         <div class="col-sm-1 col-md-1">Price</div>
         <div class="col-sm-1 col-md-1">Quantity</div>
         <div class="col-sm-1 col-md-1">Total</div>
-        <div class="col-sm-1 col-md-1">&nbsp;</div>
+        <div class="col-sm-1 col-md-2">&nbsp;</div>
       </div>
       <% @cart_items.each do |cart_item| %>
       <div class="row">
         <%= form_for(cart_item, url: cart_item_path(cart_item)) do |f| %>
-        <%= image_tag cart_item.image_url, class: "img-responsive col-sm-3 col-md-3" %>
+        <%= image_tag cart_item.image_url, class: "img-responsive col-sm-2 col-md-2" %>
         <div class="name col-sm-5 col-md-5">
           <%= cart_item.name %><br>
           <%= cart_item.description %>
+          <span class="remove-product">
+            <%= link_to "remove", cart_item_path(cart_item), method: :delete %>
+          </span>
         </div>
         <div class="item-total col-sm-1 col-md-1">$<%= cart_item.price %></div>
         <%= f.text_field(:quantity, class: "col-sm-1 col-md-1 quantity") %>
         <div class="sub-total col-sm-1 col-md-1">
           $<%= cart_item.item_total %>
         </div>
-        <div class="col-sm-1 col-md-1">
-            <%= f.submit "update", class: "btn btn-xs btn-success" %>
-          <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+        <div class="col-sm-2 col-md-2">
+          <%= f.submit "update", class: "btn btn-xs btn-success" %>
         </div>
         <% end %>
       </div> <!-- /row -->
@@ -39,4 +41,5 @@
 
   </div>
   <%= button_tag "Continue Shopping", class: "btn btn-lg btn-primary" %> <%= button_tag "Checkout", class: "btn btn-lg btn-success pull-right" %>
+
 </div><!-- /.container -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,9 +9,7 @@
 <body>
   <!-- Navigation -->
   <%= render partial: 'layouts/navigation' %>
-  <% flash.each do |type, message| %>
-    <%= content_tag :div, message, class: "alert alert-#{type}" %>
-  <% end %>
+  <%= render partial: 'partials/flash_messages' %>
 
   <%= yield %>
 

--- a/app/views/partials/_flash_messages.html.erb
+++ b/app/views/partials/_flash_messages.html.erb
@@ -1,0 +1,4 @@
+<% flash.each do |type, message| %>
+  <%= content_tag :div, sanitize(message),
+      class: "alert alert-#{type} flash" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get "/dashboard", to: "users#show"
 
   get "/cart", to: "cart_items#index"
-  resources :cart_items, only: [:create, :update]
+  resources :cart_items, only: [:create, :update, :destroy]
 
   get "/login",  to: "sessions#new"
   post "/login", to: "sessions#create"

--- a/spec/features/visitor_cart_spec.rb
+++ b/spec/features/visitor_cart_spec.rb
@@ -22,16 +22,16 @@ feature "Visitor" do
       expect(current_path).to eq(cart_path)
 
       within(".name") do
-        expect(page).to have_content("Plant 1")
+        expect(page).to have_content(item1.name)
       end
 
-      within(".row", text: "Plant 1") do
+      within(".row", text: item1.name) do
         quantity = find(".quantity").value
         expect(quantity).to eq("2")
       end
 
       within(".total") do
-        expect(page).to have_content("$39.98")
+        expect(page).to have_content("$#{item1.price * 2}")
       end
     end
 
@@ -53,18 +53,18 @@ feature "Visitor" do
       find("#cart").click
 
       expect(current_path).to eq(cart_path)
-      within(".row", text: "Plant 1") do
-        expect(page).to have_content("Plant 1")
+      within(".row", text: item1.name) do
+        expect(page).to have_content(item1.name)
         quantity = find(".quantity").value
         expect(quantity).to eq("2")
-        expect(page).to have_content("$39.98")
+        expect(page).to have_content("$#{item1.price}")
       end
 
-      within(".row", text: "Food 3") do
-        expect(page).to have_content("Food 3")
+      within(".row", text: item2.name) do
+        expect(page).to have_content(item2.name)
         quantity = find(".quantity").value
         expect(quantity).to eq("1")
-        expect(page).to have_content("$39.99")
+        expect(page).to have_content("$#{item2.price}")
       end
     end
 
@@ -78,58 +78,58 @@ feature "Visitor" do
 
       find("#cart").click
 
-      within(".row", text: "Plant 1") do
+      within(".row", text: item1.name) do
         find(".quantity").set("4")
         click_button("update")
       end
 
       expect(current_path).to eq(cart_path)
 
-      within(".row", text: "Plant 1") do
+      within(".row", text: item1.name) do
         quantity = find(".quantity").value
         expect(quantity).to eq("4")
-        expect(page).to have_content("$79.96")
+        expect(page).to have_content("$#{item1.price * 4}")
       end
 
       within(".total") do
-        expect(page).to have_content("$119.95")
+        expect(page).to have_content("$#{item1.price * 4 + item2.price}")
       end
     end
 
     scenario "adds an item twice and then decreases the quantity to one" do
-      item1 = @plants.products.first
-      visit product_path(item1)
+      item = @plants.products.first
+      visit product_path(item)
       click_button "Add to Cart"
       click_button "Add to Cart"
 
       find("#cart").click
-      within(".row", text: "Plant 1") do
+      within(".row", text: item.name) do
         quantity = find(".quantity").value
         expect(quantity).to eq("2")
-        expect(page).to have_content("$39.98")
+        expect(page).to have_content("$#{item.price * 2}")
       end
 
       within(".total") do
-        expect(page).to have_content("$39.98")
+        expect(page).to have_content("$#{item.price * 2}")
       end
 
-      within(".row", text: "Plant 1") do
+      within(".row", text: item.name) do
         find(".quantity").set("1")
         click_button("update")
       end
 
       expect(current_path).to eq(cart_path)
 
-      within(".row", text: "Plant 1") do
+      within(".row", text: item.name) do
         quantity = find(".quantity").value
         expect(quantity).to eq("1")
         within(".sub-total") do
-          expect(page).to have_content("$19.99")
+          expect(page).to have_content("$#{item.price}")
         end
       end
 
       within(".total") do
-        expect(page).to have_content("$19.99")
+        expect(page).to have_content("$#{item.price}")
       end
     end
 
@@ -139,33 +139,33 @@ feature "Visitor" do
       click_button "Add to Cart"
 
       find("#cart").click
-      within(".row", text: "Plant 1") do
+      within(".row", text: item.name) do
         quantity = find(".quantity").value
         expect(quantity).to eq("1")
-        expect(page).to have_content("$19.99")
+        expect(page).to have_content("$#{item.price}")
       end
 
       within(".total") do
-        expect(page).to have_content("$19.99")
+        expect(page).to have_content("$#{item.price}")
       end
 
-      within(".row", text: "Plant 1") do
+      within(".row", text: item.name) do
         click_link("remove")
       end
 
       expect(current_path).to eq(cart_path)
 
       within(".flash") do
-        expect(page).to have_content("Successfully removed Plant 1 " \
+        expect(page).to have_content("Successfully removed #{item.name} " \
           "from your cart")
-        expect(page).to have_link("Plant 1")
-        expect(page).to have_xpath("//a[@href=\"/products/77\"]")
+        expect(page).to have_link(item.name)
+        expect(page).to have_xpath("//a[@href=\"/products/#{item.id}\"]")
       end
 
-      expect(page).not_to have_content("This is the description for plant 1")
+      expect(page).not_to have_content(item.description)
 
       within(".total") do
-        expect(page).not_to have_content("$19.99")
+        expect(page).not_to have_content("$#{item.price}")
         expect(page).to have_content("$0")
       end
     end

--- a/spec/features/visitor_cart_spec.rb
+++ b/spec/features/visitor_cart_spec.rb
@@ -134,8 +134,8 @@ feature "Visitor" do
     end
 
     scenario "adds an item and then clicks the remove link" do
-      item1 = @plants.products.first
-      visit product_path(item1)
+      item = @plants.products.first
+      visit product_path(item)
       click_button "Add to Cart"
 
       find("#cart").click
@@ -154,11 +154,13 @@ feature "Visitor" do
       end
 
       expect(current_path).to eq(cart_path)
-      skip
-      expect(page).to have_content("Successfully removed Plant 1 from your" \
-        "cart")
-      expect(page).to have_link("Plant 1")
-      expect(page).to have_xpath("//a[@href=\"/products/1\"]")
+
+      within(".flash") do
+        expect(page).to have_content("Successfully removed Plant 1 " \
+          "from your cart")
+        expect(page).to have_link("Plant 1")
+        expect(page).to have_xpath("//a[@href=\"/products/77\"]")
+      end
 
       expect(page).not_to have_content("This is the description for plant 1")
 

--- a/spec/features/visitor_cart_spec.rb
+++ b/spec/features/visitor_cart_spec.rb
@@ -132,5 +132,38 @@ feature "Visitor" do
         expect(page).to have_content("$19.99")
       end
     end
+
+    xscenario "adds an item and then clicks the remove link" do
+      item1 = @plants.products.first
+      visit product_path(item1)
+      click_button "Add to Cart"
+
+      find("#cart").click
+      within(".row", text: "Plant 1") do
+        quantity = find(".quantity").value
+        expect(quantity).to eq("1")
+        expect(page).to have_content("$19.99")
+      end
+
+      within(".total") do
+        expect(page).to have_content("$19.99")
+      end
+
+      within(".row", text: "Plant 1") do
+        click_button("remove")
+      end
+
+      expect(current_path).to eq(cart_path)
+      expect(page).to have_content("Successfully removed Plant 1 from your" \
+        "cart")
+      expect(page).to have_link("Plant 1")
+      expect(page).to have_xpath("//a[@href=\"/products/1\"]")
+
+      expect(page).not_to have_content("This is the description for plant 1")
+
+      within(".total") do
+        expect(page).not_to have_content("$19.99")
+      end
+    end
   end
 end

--- a/spec/features/visitor_cart_spec.rb
+++ b/spec/features/visitor_cart_spec.rb
@@ -133,7 +133,7 @@ feature "Visitor" do
       end
     end
 
-    xscenario "adds an item and then clicks the remove link" do
+    scenario "adds an item and then clicks the remove link" do
       item1 = @plants.products.first
       visit product_path(item1)
       click_button "Add to Cart"
@@ -150,10 +150,11 @@ feature "Visitor" do
       end
 
       within(".row", text: "Plant 1") do
-        click_button("remove")
+        click_link("remove")
       end
 
       expect(current_path).to eq(cart_path)
+      skip
       expect(page).to have_content("Successfully removed Plant 1 from your" \
         "cart")
       expect(page).to have_link("Plant 1")
@@ -163,6 +164,7 @@ feature "Visitor" do
 
       within(".total") do
         expect(page).not_to have_content("$19.99")
+        expect(page).to have_content("$0")
       end
     end
   end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -48,6 +48,19 @@ describe Cart do
     end
   end
 
+  context "#update_item_quantity" do
+    it "updates the data method when a product is added" do
+      input_data = {}
+      input_data[product.id.to_s] = 2
+      cart = Cart.new(input_data)
+
+      expect(cart.data).to eq(product.id.to_s => 2)
+
+      cart.update_item_quantity(product, 4)
+      expect(cart.data).to eq(product.id.to_s => 4)
+    end
+  end
+
   context "#delete_item" do
     it "removes the product from data" do
       input_data = {}

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -48,6 +48,19 @@ describe Cart do
     end
   end
 
+  context "#delete_item" do
+    it "removes the product from data" do
+      input_data = {}
+      input_data[product.id.to_s] = 2
+      cart = Cart.new(input_data)
+
+      expect(cart.data).to eq(product.id.to_s => 2)
+
+      cart.delete_item(product)
+      expect(cart.data).to eq({})
+    end
+  end
+
   context "#total_price" do
     it "returns the total price for the cart" do
       cart = Cart.new(nil)


### PR DESCRIPTION
Add capability to remove items from the cart.
When a product is removed the user will see a green bar appear telling them that the item has been removed.  The product name in the message is hyperlinked so they can return to the product page for the item if they wish to.
When a product is remove, it no longer appears in the cart, and the total cart value is updated accordingly.