### PR TITLE
Adds validation for order_items quantity

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,6 +1,7 @@
 class OrderItem < ActiveRecord::Base
   belongs_to :order
   belongs_to :product
+  validates :quantity, numericality: { greater_than: 0 }
 
   def subtotal
     unit_price * quantity

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -43,4 +43,14 @@ RSpec.describe OrderItem, type: :model do
     expect(@order_item.created_at).to be_a_kind_of(ActiveSupport::TimeWithZone)
     expect(@order_item.updated_at).to be_a_kind_of(ActiveSupport::TimeWithZone)
   end
+
+  it "cant have a quantity of zero" do
+    @order_item.update(quantity: 0)
+    expect(@order_item).to be_invalid
+  end
+
+  it "cant have a negative quantity" do
+    @order_item.update(quantity: -5)
+    expect(@order_item).to be_invalid
+  end
 end


### PR DESCRIPTION
https://waffle.io/michael-reeves/redrum_nursery/cards/55c90a593882733b00e0d86d

Why:
A user shouldn't be able to order 0 items or a quantity of a negative
number.

This change addresses the need by:
* adding validation for order_items qty to only accept numbers greater than zero
* adding associated tests