### PR TITLE
Update retired product spec to validate on a dynamic path

### DIFF
--- a/spec/features/display_active_and_retired_products_spec.rb
+++ b/spec/features/display_active_and_retired_products_spec.rb
@@ -51,7 +51,7 @@ feature "a user" do
   scenario "can access a retired product but cannot add it to the cart" do
     visit product_path(@plant3)
 
-    expect(current_path).to eq "/products/11"
+    expect(current_path).to eq product_path(@plant3)
     expect(page).to have_css("input[value*='Retired']")
   end
 end


### PR DESCRIPTION
Update spec scenario to use a dynamic path rather than a hardcoded path. The hardcoded path would fail if RSpec was set to execute tests in a random order. Now, the test works regardless of order executed.