### PR TITLE
Add addresses to Admin::Orders#show page and include spec

### DIFF
--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -9,17 +9,38 @@
   </div>
   <br/>
   <h5><strong>User:</strong> <%= @order.user.full_name %></h5>
-  <br/>
+
   <div class="row">
     <div class="col-md-6">
       <h5><strong>Billing Address</strong></h5>
-      <%#= render partial: "partials/address", locals: { address = @order.user.addresses.billing } %>
+      <% @order.user.addresses.billing.each do |address| %>
+        <p>
+          <%= address.address_1 %><br>
+          <% if address.address_2 %>
+            <%= address.address_2 %><br>
+          <% end %>
+          <%= address.city %>,
+          <%= address.state %>
+          <%= address.zip_code %>
+        </p>
+      <% end %>
     </div>
     <div class="col-md-6">
       <h5><strong>Shipping Address</strong></h5>
-      <%#= render partial: "partials/address", locals: { address = @order.user.addresses.shipping } %>
+      <% @order.user.addresses.shipping.each do |address| %>
+      <p>
+        <%= address.address_1 %>
+        <%= address.address_2 %>
+        <%= address.city %>
+        <%= address.state %>
+        <%= address.zip_code %>
+      </p>
+      <% end %>
     </div>
-  </div><br>
+  </div>
+
+  <br><br>
+
   <div class="table-responsive">
     <%= render partial: "partials/single_order_table" %>
     <% if @order.status == "cancelled" || @order.status == "completed" %>

--- a/app/views/partials/_address.html.erb
+++ b/app/views/partials/_address.html.erb
@@ -1,7 +1,0 @@
-<p>
-  <%= address.address1 %>
-  <%= address.address1 %>
-  <%= address.city %>
-  <%= address.state %>
-  <%= address.zip_code %>
-</p>

--- a/spec/features/admin_can_view_order_details_spec.rb
+++ b/spec/features/admin_can_view_order_details_spec.rb
@@ -24,6 +24,14 @@ feature "admin user" do
                        email:      "jane@doe.com",
                        password:   "password")
 
+    user.addresses.create(type_of: "billing",
+                          address_1: "1234 Main St", city: "Seattle",
+                          state: "WA", zip_code: 98111)
+
+    user.addresses.create(type_of: "shipping",
+                          address_1: "5678 South Ave", city: "Seattle",
+                          state: "WA", zip_code: 98222)
+
     order = user.orders.create(status: "ordered",
                        created_at: DateTime.civil(2015, 07, 05, 21, 33, 0),
                        updated_at: DateTime.civil(2015, 07, 05, 21, 33, 0))
@@ -51,6 +59,12 @@ feature "admin user" do
     expect(page).to have_content("Purchase Date/Time: " \
                                  "July  5, 2015 at  9:33 PM")
     expect(page).to have_content("Jane Doe")
+
+    expect(page).to have_content("1234 Main St")
+    expect(page).to have_content("98111")
+
+    expect(page).to have_content("5678 South Ave")
+    expect(page).to have_content("98222")
 
     within("tr", text: "Plant 1") do
       expect(page).to have_content("ordered")


### PR DESCRIPTION
Include user addresses on the Admin view of the individual order page